### PR TITLE
Fixing backticks to remove errors from cloud foundry push

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -107,7 +107,7 @@ bpwatch start pre_compile
   source $BIN_DIR/steps/hooks/pre_compile
 bpwatch stop pre_compile
 
-echo "If no requirements given, assume `setup.py develop`."
+echo "If no requirements given, assume 'setup.py develop'."
 if [ ! -f requirements.txt ]; then
   puts-step "No requirements.txt provided; assuming dist package."
   echo "-e ." > requirements.txt
@@ -136,7 +136,7 @@ bpwatch start restore_cache
 bpwatch stop restore_cache
 
 set +e
-echo "Create set-aside `.heroku` folder."
+echo "Create set-aside '.heroku' folder."
 mkdir .heroku &> /dev/null
 set -e
 


### PR DESCRIPTION
Noticed errors in the logs when pushing to bluemix (using cf). Issue is related to unescaped backticks in comments echoed. Replaced backticks with single quotes.

```
Prepend proper path buildpack use.
Switch to the repo's context.
Experimental pre_compile hook.
/tmp/buildpacks/heroku-buildpack-python/bin/compile: line 110: setup.py: command not found
If no requirements given, assume .
If no runtime given, assume default version.
-----> No runtime.txt provided; assuming python-2.7.4.
# Purge old-style virtualenvs.
Restore old artifacts from the cache.
/tmp/buildpacks/heroku-buildpack-python/bin/compile: line 139: .heroku: command not found
Create set-aside  folder.
Install Python.
```
